### PR TITLE
Fix click-and-drop + load data onto /game page

### DIFF
--- a/src/Components/Play/HumanVsHuman.jsx
+++ b/src/Components/Play/HumanVsHuman.jsx
@@ -106,16 +106,11 @@ class HumanVsHuman extends Component {
             });
     };
 
-<<<<<<< HEAD
     /** Loads the game for the first time (synchronises client's board with server's internal board) */
     loadGame = () => {
         // Send the GET request to the server
         var self = this;
         axios.get(`https://negativei2-server.herokuapp.com/getgame/${self.props.gameid}`)
-=======
-        // send request to server
-        axios.post('https://negativei2-server.herokuapp.com/makemove', formData)
->>>>>>> master
             .then(function(response) {
                 var fen = response.data.fen;
                 self.game.load(fen);


### PR DESCRIPTION
# Features

This pull request was only intended to fix #61, but also found it appropriate to fix a few other things too:

- [x] Fix pieces only moving properly on drag-and-drop.
- [x] Restructure `HumanVsHuman.jsx` to move logic for click-and-drop & drag-and-drop to one function
- [x] Load game data from server when `/play/game-id` page is loaded:
  - Loads the game onto the board (#34)
  - Loads all played moves into the move tracker
  - Updates the turn indicator
- [x] Change HTTP links to HTTPS (on `/play` page). <br>*Though this is already covered in #76*.

# Issues

**I've noticed a significant delay whenever moves are made (in this branch), this could be due to having to load games from Firebase, and update the internal game object after every move.**

**There is also sometimes a significant delay in loading a game (especially if it is a long one), but this can be fixed by adjusting how the spinner works on this page.**

For now, I think it's important that we have a functioning application, since that is our goal for demo 3 - optimization can be done later.

# Demo

Try loading `/play/eGJB6E1OQUXkjgFyZ4Th` (a 69 move game), or any other game stored on Firebase - it should correctly load the game onto the board, and load the moves into the move tracker, and correctly display the turn on the turn indicator.