### PR TITLE
Add speech mapping 'fh' -> 'f'

### DIFF
--- a/src/Components/Play/Sidebar.jsx
+++ b/src/Components/Play/Sidebar.jsx
@@ -69,7 +69,7 @@ class Sidebar extends Component {
             eh: 'a',
             bee: 'b', be: 'b', me: 'b',
             see: 'c', sea: 'c',
-            of: 'f',
+            of: 'f', fh: 'f',
             one: '1', won: '1',
             two: '2', to: '2', too: '2',
             three: '3', tree: '3', free: '3',


### PR DESCRIPTION
Adds a speech substitution for `fh` to `f`, since this appears to be commonly misheard.