### PR TITLE
Change class attribute occurences to className

### DIFF
--- a/src/Components/Play/Sidebar.jsx
+++ b/src/Components/Play/Sidebar.jsx
@@ -244,7 +244,7 @@ class Sidebar extends Component {
                             <div id="spectator-draw-received" className="confirmation-box">
                                 <div id="draw-received" className="confirmation-content">
                                     <p>A draw offer has been sent.</p>
-                                    <div class="button-container">
+                                    <div className="button-container">
                                         <button id="spectator-draw-close" className="button small small-font">Close</button>
                                     </div>
                                 </div>
@@ -252,7 +252,7 @@ class Sidebar extends Component {
                             <div id="draw-rejection-confirmation" className="confirmation-box">
                                 <div id="rejection-confirmation" className="confirmation-content">
                                     <p>The draw offer was rejected.</p>
-                                    <div class="button-container">
+                                    <div className="button-container">
                                         <button id="close-rejection" className="button small small-font">Close</button>
                                     </div>
                                 </div>
@@ -268,7 +268,7 @@ class Sidebar extends Component {
                             <div id="spectator-forfeit-confirmation" className="confirmation-box">
                                 <div id="opponent-forfeit" className="confirmation-content">
                                     <p>The game has been forfeited.</p>
-                                    <div class="button-container">
+                                    <div className="button-container">
                                         <button id="spectator-close-forfeit" className="button small small-font">Close</button>
                                     </div>
                                 </div>


### PR DESCRIPTION
`Sidebar` currently generates warnings due to the presence of `class` in some HTML attributes, when React expects then to be `className`.

This PR fixes that.